### PR TITLE
Hide command line output when verbosity is set to quiet

### DIFF
--- a/src/process.js
+++ b/src/process.js
@@ -9,7 +9,7 @@ module.exports = function run(command) {
 
     if (!windows) command.args.unshift(command.path);
 
-    if (options.verbosity !== 'quiet') {
+    if (command.options.verbosity !== 'quiet') {
         console.log();
         console.log(path + ' ' + args.join(' '));
         console.log();

--- a/src/process.js
+++ b/src/process.js
@@ -9,9 +9,11 @@ module.exports = function run(command) {
 
     if (!windows) command.args.unshift(command.path);
 
-    console.log();
-    console.log(path + ' ' + args.join(' '));
-    console.log();
+    if (options.verbosity !== 'quiet') {
+        console.log();
+        console.log(path + ' ' + args.join(' '));
+        console.log();
+    }
 
     var nuget = child.spawn(path, args, {
         cwd: command.options.cwd


### PR DESCRIPTION
This makes sure that code using the library can hide all output if desired.
