### PR TITLE
Fix TypeError: Bad argument error that occurs if user specifies a falsy value as nugetPath

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -179,12 +179,11 @@ function addNonInteractive(args, options) {
 }
 
 module.exports = function(defaults) {
-    defaults = _.extend({ nugetPath: 'nuget.exe' }, defaults);
     return function(command, args, options) {
         options = _.extend({}, defaults, options);
         return {
             options: options,
-            path: options.nugetPath,
+            path: options.nugetPath || 'nuget.exe',
             args: commands[command].apply(this, args.concat(options))
         }
     }

--- a/test/process.spec.js
+++ b/test/process.spec.js
@@ -35,12 +35,7 @@ describe('process', function() {
     });
 
     var exceptionMessage =
-        "Nuget failed: UnhandledException:System.Exception:ohnoes!" + 
-        "at ConsoleApp.Program.Main(System.String[]args) " +
-        "[0x00000]in<filename unknown>:0" +
-        "[ERROR]FATALUNHANDLEDEXCEPTION:System.Exception:" +
-        "ohnoes! atConsoleApp.Program.Main(System.String[] " +
-        "args)[0x00000]in<filename unknown>:0";
+        "Nugetfailed:UnhandledException:System.Exception:ohnoes!atConsoleApp.Program.Main(String[]args)";
 
     it('should fail on exception', function(done) {
         run([ 'exception', 'oh noes!' ])


### PR DESCRIPTION
Fixed and error and fixed a test.

The error occurred when the user specified a falsy value as `nugetPath`:

```
nuget.restore({
     nugetPath: undefined,
     cwd: BUILDENV.paths.dest.webtiers.mvc,
     verbosity: 'quiet'
});
```

![image](https://cloud.githubusercontent.com/assets/900997/12742295/5b039162-c952-11e5-9574-0547b3458ca2.png)
